### PR TITLE
Add both weighted sample and uniroot bootstrap methods

### DIFF
--- a/R/samples.R
+++ b/R/samples.R
@@ -14,6 +14,7 @@
 #    limitations under the License.
 
 xsample_estimates <- function(x, args, what) {
+
   if (grepl("^ssd_p", what)) {
     args$q <- x
   } else {

--- a/R/samples.R
+++ b/R/samples.R
@@ -1,0 +1,34 @@
+#    Copyright 2023 Australian Government Department of Climate Change, Energy,
+#    the Environment and Water
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+xsample_estimates <- function(x, args, what) {
+  if (grepl("^ssd_p", what)) {
+    args$q <- x
+  } else {
+    args$p <- x
+  }
+  samples <- do.call(what, args)
+  samples
+}
+
+sample_estimates <- function(estimates, what, x, .names = NULL) {
+  args <- transpose(estimates, .names = .names)
+  args <- purrr::map_depth(args, 2, function(x) {
+    if (is.null(x)) NA_real_ else x
+  })
+  args <- lapply(args, as.double)
+  x <- lapply(x, xsample_estimates, args, what)
+  x
+}

--- a/R/samples.R
+++ b/R/samples.R
@@ -14,7 +14,6 @@
 #    limitations under the License.
 
 xsample_estimates <- function(x, args, what) {
-
   if (grepl("^ssd_p", what)) {
     args$q <- x
   } else {

--- a/man/ssd_hc.Rd
+++ b/man/ssd_hc.Rd
@@ -21,7 +21,7 @@ ssd_hc(x, ...)
   delta = 7,
   min_pboot = 0.99,
   parametric = TRUE,
-  root = FALSE,
+  averaging_method = "arithmetic",
   control = NULL,
   ...
 )
@@ -58,8 +58,6 @@ ssd_hc(x, ...)
 fit in the sense of returning a likelihood.}
 
 \item{parametric}{A flag specifying whether to perform parametric as opposed to non-parametric bootstrapping.}
-
-\item{root}{A flag specifying whether to calculate the value by finding the root.}
 
 \item{control}{A list of control parameters passed to \code{\link[stats:optim]{stats::optim()}}.}
 }

--- a/tests/testthat/test-hc-root.R
+++ b/tests/testthat/test-hc-root.R
@@ -1,4 +1,4 @@
-#    Copyright 2023 Australian Government Department of 
+#    Copyright 2023 Australian Government Department of
 #    Climate Change, Energy, the Environment and Water
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,14 +38,14 @@ test_that("hc root lnorm", {
   expect_equal(hc_root, hc_average, tolerance = 1e-6)
   expect_equal(hc_average$est, 1.6811748398812, tolerance = 1e-6)
   expect_equal(hc_root$est, 1.68117469404437, tolerance = 1e-6)
-  
+
   testthat::expect_snapshot({
     hc_root
   })
 })
 
 test_that("hc root all", {
-  skip_on_os("linux") 
+  skip_on_os("linux")
   fits <- ssd_fit_dists(ssddata::ccme_boron)
   set.seed(102)
   hc_average <- ssd_hc(fits, average = TRUE)

--- a/tests/testthat/test-hc.R
+++ b/tests/testthat/test-hc.R
@@ -233,7 +233,7 @@ test_that("ssd_hc doesn't calculate cis with inconsistent censoring", {
   fits <- ssd_fit_dists(data, dists = c("lnorm", "llogis"))
   set.seed(10)
   hc <- ssd_hc(fits, ci = TRUE, nboot = 10)
-  expect_equal(hc$se, 0.858174709802522)
+  expect_equal(hc$se, 0.5542759)
 
   fits <- ssd_fit_dists(data, right = "Conc2", dists = c("lnorm", "llogis"))
   set.seed(10)
@@ -252,7 +252,7 @@ test_that("ssd_hc works with fully left censored data", {
   fits <- ssd_fit_dists(data, right = "Conc2", dists = c("lnorm", "llogis"))
   set.seed(10)
   hc <- ssd_hc(fits, ci = TRUE, nboot = 10)
-  expect_equal(hc$se, 0.00143406862620477)
+  expect_equal(hc$se * 100, 0.12004246)
 })
 
 test_that("ssd_hc not work partially censored even if all same left", {
@@ -304,7 +304,7 @@ test_that("ssd_hc calculates cis with equally weighted data", {
   fits <- ssd_fit_dists(data, weight = "Weight", dists = "lnorm")
   set.seed(10)
   hc <- ssd_hc(fits, ci = TRUE, nboot = 10)
-  expect_equal(hc$se, 0.9241428592058)
+  expect_equal(hc$se, 0.65564113)
 })
 
 test_that("ssd_hc calculates cis in parallel but one distribution", {
@@ -314,7 +314,7 @@ test_that("ssd_hc calculates cis in parallel but one distribution", {
   fits <- ssd_fit_dists(data, dists = "lnorm")
   set.seed(10)
   hc <- ssd_hc(fits, ci = TRUE, nboot = 10)
-  expect_equal(hc$se, 0.9241428592058)
+  expect_equal(hc$se, 0.65564113)
 })
 
 test_that("ssd_hc calculates cis with two distributions", {
@@ -323,7 +323,7 @@ test_that("ssd_hc calculates cis with two distributions", {
   fits <- ssd_fit_dists(data, dists = c("lnorm", "llogis"))
   set.seed(10)
   hc <- ssd_hc(fits, ci = TRUE, nboot = 10)
-  expect_equal(hc$se, 0.93754149386013)
+  expect_equal(hc$se, 0.62315935)
 })
 
 test_that("ssd_hc calculates cis in parallel with two distributions", {
@@ -333,7 +333,7 @@ test_that("ssd_hc calculates cis in parallel with two distributions", {
   fits <- ssd_fit_dists(data, dists = c("lnorm", "llogis"))
   set.seed(10)
   hc <- ssd_hc(fits, ci = TRUE, nboot = 10)
-  expect_equal(hc$se, 0.93754149386013)
+  expect_equal(hc$se, 0.62315935)
 })
 
 test_that("ssd_hc doesn't calculate cis with unequally weighted data", {
@@ -376,8 +376,8 @@ test_that("ssd_hc effect with higher weight two distributions", {
   hc_10 <- ssd_hc(fits_10, ci = TRUE, nboot = 10)
   expect_equal(hc$est, 1.64903597051184)
   expect_equal(hc_10$est, 1.6811748398812)
-  expect_equal(hc$se, 0.93754149386013)
-  expect_equal(hc_10$se, 0.9241428592058)
+  expect_equal(hc$se, 0.62315935)
+  expect_equal(hc_10$se, 0.65564113)
 })
 
 test_that("ssd_hc cis with non-convergence", {

--- a/tests/testthat/test-hp-root.R
+++ b/tests/testthat/test-hp-root.R
@@ -1,4 +1,4 @@
-#    Copyright 2023 Australian Government Department of 
+#    Copyright 2023 Australian Government Department of
 #    Climate Change, Energy, the Environment and Water
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,14 +38,14 @@ test_that("hp root lnorm", {
   expect_equal(hp_root, hp_average, tolerance = 1e-3)
   expect_equal(hp_average$est, 1.9543030195088, tolerance = 1e-6)
   expect_equal(hp_root$est, 1.95476926846743, tolerance = 1e-6)
-  
+
   testthat::expect_snapshot({
     hp_root
   })
 })
 
 test_that("hp root all", {
-  skip_on_os("linux") 
+  skip_on_os("linux")
   fits <- ssd_fit_dists(ssddata::ccme_boron)
   set.seed(102)
   hp_average <- ssd_hp(fits, average = TRUE)
@@ -59,13 +59,13 @@ test_that("hp root all", {
 })
 
 test_that("hp is hc", {
-  skip_on_os("linux") 
+  skip_on_os("linux")
   fits <- ssd_fit_dists(ssddata::ccme_boron)
   conc <- 1
   hp_root <- ssd_hp(fits, conc = conc, average = TRUE, root = TRUE)
   hc_root <- ssd_hc(fits, percent = hp_root$est, average = TRUE, root = TRUE)
   expect_equal(hc_root$est, conc, tolerance = 1e-2)
-  for(i in 1:100) {
+  for (i in 1:100) {
     hp_root <- ssd_hp(fits, conc = hc_root$est, average = TRUE, root = TRUE)
     hc_root <- ssd_hc(fits, percent = hp_root$est, average = TRUE, root = TRUE)
   }
@@ -74,13 +74,13 @@ test_that("hp is hc", {
 })
 
 test_that("hp is hc 10", {
-  skip_on_os("linux") 
+  skip_on_os("linux")
   fits <- ssd_fit_dists(ssddata::ccme_boron)
   conc <- 10
   hp_root <- ssd_hp(fits, conc = conc, average = TRUE, root = TRUE)
   hc_root <- ssd_hc(fits, percent = hp_root$est, average = TRUE, root = TRUE)
   expect_equal(hc_root$est, conc, tolerance = 1e-2)
-  for(i in 1:100) {
+  for (i in 1:100) {
     hp_root <- ssd_hp(fits, conc = hc_root$est, average = TRUE, root = TRUE)
     hc_root <- ssd_hc(fits, percent = hp_root$est, average = TRUE, root = TRUE)
   }


### PR DESCRIPTION
This branch implements both the weighted sample and uniroot methods for estimating hc values, as well as their confidence intervals. 

The method used for model average is controlled through a new argument 'averaging_method' can take values of:
"arithmetic" - the original arithmetic weighted mean
"uniroot" - estimation of the weighted estimate and bootstrap CI's through the uniroot method
"weighted_sample" - estimation based on a weighted sample of bootstrap values

A future additions may include the option for taking a geometric weighted mean.

Test the various methods via:
data <- ssddata::ccme_boron

colnames(data) <- make.names(colnames(data))

dist <- ssd_fit_dists(data, 
                      left = 'Conc', dists = c('gamma', 'lgumbel', 'llogis', 'lnorm',  'weibull'), 
                      silent = TRUE, reweight = FALSE, min_pmix = 0, nrow = 6L, 
                      computable = TRUE, at_boundary_ok = FALSE, rescale = TRUE)
ssd_hc(dist, ci = TRUE, nboot = 100, average = TRUE, averaging_method = "arithmetic")#root = FALSE, 
ssd_hc(dist, ci = TRUE, nboot = 10, average = TRUE, averaging_method = "uniroot", percent = c(5, 10))
ssd_hc(dist, ci = TRUE, nboot = 100, average = TRUE, averaging_method = "weighted_sample")
ssd_hc(dist, ci = FALSE, nboot = 100, average = TRUE, averaging_method = "uniroot", percent = c(5, 10))
