### PR TITLE
Remove repeated 33-parameter blocks in multi.R

### DIFF
--- a/R/estimates.R
+++ b/R/estimates.R
@@ -60,6 +60,8 @@ estimates.fitdists <- function(x, all_estimates = FALSE, ...) {
 }
 
 .relist_estimates <- function(x) {
-  list <- relist(x, skeleton = emulti_ssd())
+  skeleton <- emulti_ssd()
+  x <- unlist(x)[names(unlist(skeleton))]
+  list <- relist(x, skeleton = skeleton)
   purrr::map(list, function(x) as.list(unlist(x)))
 }

--- a/R/multi.R
+++ b/R/multi.R
@@ -60,46 +60,7 @@ ssd_pmulti <- function(
   lower.tail = TRUE,
   log.p = FALSE
 ) {
-  pdist(
-    "multi",
-    q = q,
-    burrIII3.weight = burrIII3.weight,
-    burrIII3.shape1 = burrIII3.shape1,
-    burrIII3.shape2 = burrIII3.shape2,
-    burrIII3.scale = burrIII3.scale,
-    gamma.weight = gamma.weight,
-    gamma.shape = gamma.shape,
-    gamma.scale = gamma.scale,
-    gompertz.weight = gompertz.weight,
-    gompertz.location = gompertz.location,
-    gompertz.shape = gompertz.shape,
-    lgumbel.weight = lgumbel.weight,
-    lgumbel.locationlog = lgumbel.locationlog,
-    lgumbel.scalelog = lgumbel.scalelog,
-    llogis.weight = llogis.weight,
-    llogis.locationlog = llogis.locationlog,
-    llogis.scalelog = llogis.scalelog,
-    llogis_llogis.weight = llogis_llogis.weight,
-    llogis_llogis.locationlog1 = llogis_llogis.locationlog1,
-    llogis_llogis.scalelog1 = llogis_llogis.scalelog1,
-    llogis_llogis.locationlog2 = llogis_llogis.locationlog2,
-    llogis_llogis.scalelog2 = llogis_llogis.scalelog2,
-    llogis_llogis.pmix = llogis_llogis.pmix,
-    lnorm.weight = lnorm.weight,
-    lnorm.meanlog = lnorm.meanlog,
-    lnorm.sdlog = lnorm.sdlog,
-    lnorm_lnorm.weight = lnorm_lnorm.weight,
-    lnorm_lnorm.meanlog1 = lnorm_lnorm.meanlog1,
-    lnorm_lnorm.sdlog1 = lnorm_lnorm.sdlog1,
-    lnorm_lnorm.meanlog2 = lnorm_lnorm.meanlog2,
-    lnorm_lnorm.sdlog2 = lnorm_lnorm.sdlog2,
-    lnorm_lnorm.pmix = lnorm_lnorm.pmix,
-    weibull.weight = weibull.weight,
-    weibull.shape = weibull.shape,
-    weibull.scale = weibull.scale,
-    lower.tail = lower.tail,
-    log.p = log.p
-  )
+  do.call(pdist, c(list("multi"), as.list(environment())))
 }
 
 #' @describeIn ssd_q Quantile Function for Multiple Distributions
@@ -147,46 +108,7 @@ ssd_qmulti <- function(
   lower.tail = TRUE,
   log.p = FALSE
 ) {
-  qdist(
-    "multi",
-    p = p,
-    burrIII3.weight = burrIII3.weight,
-    burrIII3.shape1 = burrIII3.shape1,
-    burrIII3.shape2 = burrIII3.shape2,
-    burrIII3.scale = burrIII3.scale,
-    gamma.weight = gamma.weight,
-    gamma.shape = gamma.shape,
-    gamma.scale = gamma.scale,
-    gompertz.weight = gompertz.weight,
-    gompertz.location = gompertz.location,
-    gompertz.shape = gompertz.shape,
-    lgumbel.weight = lgumbel.weight,
-    lgumbel.locationlog = lgumbel.locationlog,
-    lgumbel.scalelog = lgumbel.scalelog,
-    llogis.weight = llogis.weight,
-    llogis.locationlog = llogis.locationlog,
-    llogis.scalelog = llogis.scalelog,
-    llogis_llogis.weight = llogis_llogis.weight,
-    llogis_llogis.locationlog1 = llogis_llogis.locationlog1,
-    llogis_llogis.scalelog1 = llogis_llogis.scalelog1,
-    llogis_llogis.locationlog2 = llogis_llogis.locationlog2,
-    llogis_llogis.scalelog2 = llogis_llogis.scalelog2,
-    llogis_llogis.pmix = llogis_llogis.pmix,
-    lnorm.weight = lnorm.weight,
-    lnorm.meanlog = lnorm.meanlog,
-    lnorm.sdlog = lnorm.sdlog,
-    lnorm_lnorm.weight = lnorm_lnorm.weight,
-    lnorm_lnorm.meanlog1 = lnorm_lnorm.meanlog1,
-    lnorm_lnorm.sdlog1 = lnorm_lnorm.sdlog1,
-    lnorm_lnorm.meanlog2 = lnorm_lnorm.meanlog2,
-    lnorm_lnorm.sdlog2 = lnorm_lnorm.sdlog2,
-    lnorm_lnorm.pmix = lnorm_lnorm.pmix,
-    weibull.weight = weibull.weight,
-    weibull.shape = weibull.shape,
-    weibull.scale = weibull.scale,
-    lower.tail = lower.tail,
-    log.p = log.p
-  )
+  do.call(qdist, c(list("multi"), as.list(environment())))
 }
 
 #' @describeIn ssd_r Random Generation for Multiple Distributions
@@ -235,45 +157,7 @@ ssd_rmulti <- function(
   weibull.scale = 1,
   chk = TRUE
 ) {
-  rdist(
-    "multi",
-    n = n,
-    burrIII3.weight = burrIII3.weight,
-    burrIII3.shape1 = burrIII3.shape1,
-    burrIII3.shape2 = burrIII3.shape2,
-    burrIII3.scale = burrIII3.scale,
-    gamma.weight = gamma.weight,
-    gamma.shape = gamma.shape,
-    gamma.scale = gamma.scale,
-    gompertz.weight = gompertz.weight,
-    gompertz.location = gompertz.location,
-    gompertz.shape = gompertz.shape,
-    lgumbel.weight = lgumbel.weight,
-    lgumbel.locationlog = lgumbel.locationlog,
-    lgumbel.scalelog = lgumbel.scalelog,
-    llogis.weight = llogis.weight,
-    llogis.locationlog = llogis.locationlog,
-    llogis.scalelog = llogis.scalelog,
-    llogis_llogis.weight = llogis_llogis.weight,
-    llogis_llogis.locationlog1 = llogis_llogis.locationlog1,
-    llogis_llogis.scalelog1 = llogis_llogis.scalelog1,
-    llogis_llogis.locationlog2 = llogis_llogis.locationlog2,
-    llogis_llogis.scalelog2 = llogis_llogis.scalelog2,
-    llogis_llogis.pmix = llogis_llogis.pmix,
-    lnorm.weight = lnorm.weight,
-    lnorm.meanlog = lnorm.meanlog,
-    lnorm.sdlog = lnorm.sdlog,
-    lnorm_lnorm.weight = lnorm_lnorm.weight,
-    lnorm_lnorm.meanlog1 = lnorm_lnorm.meanlog1,
-    lnorm_lnorm.sdlog1 = lnorm_lnorm.sdlog1,
-    lnorm_lnorm.meanlog2 = lnorm_lnorm.meanlog2,
-    lnorm_lnorm.sdlog2 = lnorm_lnorm.sdlog2,
-    lnorm_lnorm.pmix = lnorm_lnorm.pmix,
-    weibull.weight = weibull.weight,
-    weibull.shape = weibull.shape,
-    weibull.scale = weibull.scale,
-    chk = chk
-  )
+  do.call(rdist, c(list("multi"), as.list(environment())))
 }
 
 #' @describeIn ssd_e Default Parameter Values for Multiple Distributions
@@ -393,240 +277,20 @@ qmulti_list <- function(p, list) {
   root(p, f)
 }
 
-pmulti_ssd <- function(
-  q,
-  burrIII3.weight,
-  burrIII3.shape1,
-  burrIII3.shape2,
-  burrIII3.scale,
-  gamma.weight,
-  gamma.shape,
-  gamma.scale,
-  gompertz.weight,
-  gompertz.location,
-  gompertz.shape,
-  lgumbel.weight,
-  lgumbel.locationlog,
-  lgumbel.scalelog,
-  llogis.weight,
-  llogis.locationlog,
-  llogis.scalelog,
-  llogis_llogis.weight,
-  llogis_llogis.locationlog1,
-  llogis_llogis.scalelog1,
-  llogis_llogis.locationlog2,
-  llogis_llogis.scalelog2,
-  llogis_llogis.pmix,
-  lnorm.weight,
-  lnorm.meanlog,
-  lnorm.sdlog,
-  lnorm_lnorm.weight,
-  lnorm_lnorm.meanlog1,
-  lnorm_lnorm.sdlog1,
-  lnorm_lnorm.meanlog2,
-  lnorm_lnorm.sdlog2,
-  lnorm_lnorm.pmix,
-  weibull.weight,
-  weibull.shape,
-  weibull.scale
-) {
-  list <- .relist_estimates(
-    list(
-      burrIII3.weight = burrIII3.weight,
-      burrIII3.shape1 = burrIII3.shape1,
-      burrIII3.shape2 = burrIII3.shape2,
-      burrIII3.scale = burrIII3.scale,
-      gamma.weight = gamma.weight,
-      gamma.shape = gamma.shape,
-      gamma.scale = gamma.scale,
-      gompertz.weight = gompertz.weight,
-      gompertz.location = gompertz.location,
-      gompertz.shape = gompertz.shape,
-      lgumbel.weight = lgumbel.weight,
-      lgumbel.locationlog = lgumbel.locationlog,
-      lgumbel.scalelog = lgumbel.scalelog,
-      llogis.weight = llogis.weight,
-      llogis.locationlog = llogis.locationlog,
-      llogis.scalelog = llogis.scalelog,
-      llogis_llogis.weight = llogis_llogis.weight,
-      llogis_llogis.locationlog1 = llogis_llogis.locationlog1,
-      llogis_llogis.scalelog1 = llogis_llogis.scalelog1,
-      llogis_llogis.locationlog2 = llogis_llogis.locationlog2,
-      llogis_llogis.scalelog2 = llogis_llogis.scalelog2,
-      llogis_llogis.pmix = llogis_llogis.pmix,
-      lnorm.weight = lnorm.weight,
-      lnorm.meanlog = lnorm.meanlog,
-      lnorm.sdlog = lnorm.sdlog,
-      lnorm_lnorm.weight = lnorm_lnorm.weight,
-      lnorm_lnorm.meanlog1 = lnorm_lnorm.meanlog1,
-      lnorm_lnorm.sdlog1 = lnorm_lnorm.sdlog1,
-      lnorm_lnorm.meanlog2 = lnorm_lnorm.meanlog2,
-      lnorm_lnorm.sdlog2 = lnorm_lnorm.sdlog2,
-      lnorm_lnorm.pmix = lnorm_lnorm.pmix,
-      weibull.weight = weibull.weight,
-      weibull.shape = weibull.shape,
-      weibull.scale = weibull.scale
-    )
-  )
-
-  pmulti_list(q, list)
+# Internal model-averaged p/q/r functions dispatched by name from
+# .pdist()/.qdist()/.rdist() (see pqr.R). They receive the full set of
+# distribution parameters by name via `...`; .relist_estimates() reshapes
+# the flat named arguments into the per-distribution skeleton (and is
+# order-robust, so the order the parameters arrive in does not matter).
+pmulti_ssd <- function(q, ...) {
+  pmulti_list(q, .relist_estimates(list(...)))
 }
 
-qmulti_ssd <- function(
-  q,
-  burrIII3.weight,
-  burrIII3.shape1,
-  burrIII3.shape2,
-  burrIII3.scale,
-  gamma.weight,
-  gamma.shape,
-  gamma.scale,
-  gompertz.weight,
-  gompertz.location,
-  gompertz.shape,
-  lgumbel.weight,
-  lgumbel.locationlog,
-  lgumbel.scalelog,
-  llogis.weight,
-  llogis.locationlog,
-  llogis.scalelog,
-  llogis_llogis.weight,
-  llogis_llogis.locationlog1,
-  llogis_llogis.scalelog1,
-  llogis_llogis.locationlog2,
-  llogis_llogis.scalelog2,
-  llogis_llogis.pmix,
-  lnorm.weight,
-  lnorm.meanlog,
-  lnorm.sdlog,
-  lnorm_lnorm.weight,
-  lnorm_lnorm.meanlog1,
-  lnorm_lnorm.sdlog1,
-  lnorm_lnorm.meanlog2,
-  lnorm_lnorm.sdlog2,
-  lnorm_lnorm.pmix,
-  weibull.weight,
-  weibull.shape,
-  weibull.scale
-) {
-  list <- .relist_estimates(
-    list(
-      burrIII3.weight = burrIII3.weight,
-      burrIII3.shape1 = burrIII3.shape1,
-      burrIII3.shape2 = burrIII3.shape2,
-      burrIII3.scale = burrIII3.scale,
-      gamma.weight = gamma.weight,
-      gamma.shape = gamma.shape,
-      gamma.scale = gamma.scale,
-      gompertz.weight = gompertz.weight,
-      gompertz.location = gompertz.location,
-      gompertz.shape = gompertz.shape,
-      lgumbel.weight = lgumbel.weight,
-      lgumbel.locationlog = lgumbel.locationlog,
-      lgumbel.scalelog = lgumbel.scalelog,
-      llogis.weight = llogis.weight,
-      llogis.locationlog = llogis.locationlog,
-      llogis.scalelog = llogis.scalelog,
-      llogis_llogis.weight = llogis_llogis.weight,
-      llogis_llogis.locationlog1 = llogis_llogis.locationlog1,
-      llogis_llogis.scalelog1 = llogis_llogis.scalelog1,
-      llogis_llogis.locationlog2 = llogis_llogis.locationlog2,
-      llogis_llogis.scalelog2 = llogis_llogis.scalelog2,
-      llogis_llogis.pmix = llogis_llogis.pmix,
-      lnorm.weight = lnorm.weight,
-      lnorm.meanlog = lnorm.meanlog,
-      lnorm.sdlog = lnorm.sdlog,
-      lnorm_lnorm.weight = lnorm_lnorm.weight,
-      lnorm_lnorm.meanlog1 = lnorm_lnorm.meanlog1,
-      lnorm_lnorm.sdlog1 = lnorm_lnorm.sdlog1,
-      lnorm_lnorm.meanlog2 = lnorm_lnorm.meanlog2,
-      lnorm_lnorm.sdlog2 = lnorm_lnorm.sdlog2,
-      lnorm_lnorm.pmix = lnorm_lnorm.pmix,
-      weibull.weight = weibull.weight,
-      weibull.shape = weibull.shape,
-      weibull.scale = weibull.scale
-    )
-  )
-
-  qmulti_list(q, list)
+qmulti_ssd <- function(p, ...) {
+  qmulti_list(p, .relist_estimates(list(...)))
 }
 
-rmulti_ssd <- function(
-  n,
-  burrIII3.weight,
-  burrIII3.shape1,
-  burrIII3.shape2,
-  burrIII3.scale,
-  gamma.weight,
-  gamma.shape,
-  gamma.scale,
-  gompertz.weight,
-  gompertz.location,
-  gompertz.shape,
-  lgumbel.weight,
-  lgumbel.locationlog,
-  lgumbel.scalelog,
-  llogis.weight,
-  llogis.locationlog,
-  llogis.scalelog,
-  llogis_llogis.weight,
-  llogis_llogis.locationlog1,
-  llogis_llogis.scalelog1,
-  llogis_llogis.locationlog2,
-  llogis_llogis.scalelog2,
-  llogis_llogis.pmix,
-  lnorm.weight,
-  lnorm.meanlog,
-  lnorm.sdlog,
-  lnorm_lnorm.weight,
-  lnorm_lnorm.meanlog1,
-  lnorm_lnorm.sdlog1,
-  lnorm_lnorm.meanlog2,
-  lnorm_lnorm.sdlog2,
-  lnorm_lnorm.pmix,
-  weibull.weight,
-  weibull.shape,
-  weibull.scale
-) {
+rmulti_ssd <- function(n, ...) {
   p <- runif(n)
-
-  list <- .relist_estimates(
-    list(
-      burrIII3.weight = burrIII3.weight,
-      burrIII3.shape1 = burrIII3.shape1,
-      burrIII3.shape2 = burrIII3.shape2,
-      burrIII3.scale = burrIII3.scale,
-      gamma.weight = gamma.weight,
-      gamma.shape = gamma.shape,
-      gamma.scale = gamma.scale,
-      gompertz.weight = gompertz.weight,
-      gompertz.location = gompertz.location,
-      gompertz.shape = gompertz.shape,
-      lgumbel.weight = lgumbel.weight,
-      lgumbel.locationlog = lgumbel.locationlog,
-      lgumbel.scalelog = lgumbel.scalelog,
-      llogis.weight = llogis.weight,
-      llogis.locationlog = llogis.locationlog,
-      llogis.scalelog = llogis.scalelog,
-      llogis_llogis.weight = llogis_llogis.weight,
-      llogis_llogis.locationlog1 = llogis_llogis.locationlog1,
-      llogis_llogis.scalelog1 = llogis_llogis.scalelog1,
-      llogis_llogis.locationlog2 = llogis_llogis.locationlog2,
-      llogis_llogis.scalelog2 = llogis_llogis.scalelog2,
-      llogis_llogis.pmix = llogis_llogis.pmix,
-      lnorm.weight = lnorm.weight,
-      lnorm.meanlog = lnorm.meanlog,
-      lnorm.sdlog = lnorm.sdlog,
-      lnorm_lnorm.weight = lnorm_lnorm.weight,
-      lnorm_lnorm.meanlog1 = lnorm_lnorm.meanlog1,
-      lnorm_lnorm.sdlog1 = lnorm_lnorm.sdlog1,
-      lnorm_lnorm.meanlog2 = lnorm_lnorm.meanlog2,
-      lnorm_lnorm.sdlog2 = lnorm_lnorm.sdlog2,
-      lnorm_lnorm.pmix = lnorm_lnorm.pmix,
-      weibull.weight = weibull.weight,
-      weibull.shape = weibull.shape,
-      weibull.scale = weibull.scale
-    )
-  )
-  qmulti_list(p, list)
+  qmulti_list(p, .relist_estimates(list(...)))
 }


### PR DESCRIPTION
Addresses the largest maintainability hazard flagged in the code review: the six model-averaged `multi` functions each hard-coded the full ~33-parameter set, so adding or renaming a distribution parameter meant editing six identical blocks where a typo could silently diverge.

## Changes

- **`.relist_estimates()` is now order-robust** — it reshapes the flat parameter arguments to the canonical skeleton *by name* before `relist()` (which is positional). Previously the explicit `list(...)` blocks in the internal functions were load-bearing precisely because they re-established canonical order; with the name-based reshape, the order parameters arrive in no longer matters. This also removes a latent fragility (a non-canonical argument order would otherwise silently mis-map parameters).
- **Internal `pmulti_ssd`/`qmulti_ssd`/`rmulti_ssd`** collapse to `function(q/p/n, ...)` forwarding `list(...)` to `.relist_estimates()`. `qmulti_ssd`'s first argument is renamed `q` -> `p` (it is a probability).
- **Exported `ssd_pmulti`/`ssd_qmulti`/`ssd_rmulti`** keep their explicit signatures (so argument names and defaults stay validated and documented) but replace the verbatim forwarding bodies with `do.call(<dist>, c(list("multi"), as.list(environment())))`.

`multi.R` drops from 632 to 296 lines. The exported signatures are unchanged, so the generated `ssd_p`/`ssd_q`/`ssd_r` Rd usage is unaffected (no doc regeneration needed).

## Verification

The compiled TMB DLL will not load in the dev sandbox, so the test suite was not run here. Output was instead verified **byte-identical to the previous implementation** by injecting both the old (pre-refactor) and new versions of the seven changed functions into the installed namespace and comparing across a battery of inputs: p/q/r, distribution mixtures, weights not summing to 1, seeded random generation, p/q round-trips, the **non-canonical argument-order path** (which exercises the new name-based reshape), and the zero-weight error. All identical.

Please still run `devtools::test()` (especially `test-multi`) and `devtools::check()` locally before merge.

Independent of #160 (touches different files); both branch from `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)