### PR TITLE
Replace eval(parse()) metaprogramming with direct dispatch

### DIFF
--- a/R/multi.R
+++ b/R/multi.R
@@ -231,23 +231,19 @@ emulti_ssd <- function() {
   })
 }
 
-value_args <- function(x) {
-  x$weight <- NULL
-  value_args <- purrr::imap_chr(x, function(x, y) paste(y, "=", x))
-  paste0(value_args, collapse = ", ")
-}
-
-pmulti_dist <- function(x, dist) {
-  fun <- paste0(x$weight, " * p", dist, "_ssd(q, ")
-  value_args <- value_args(x)
-  paste0(fun, value_args, ")")
-}
-
-pmulti_fun <- function(list) {
-  funs <- purrr::imap_chr(list, pmulti_dist)
-  fun <- paste0(funs, collapse = " + ")
-  func <- paste0("function(q, p = 0) {(", fun, ") - p}")
-  eval(parse(text = func))
+# Build the model-averaged CDF as a closure: the weighted sum of the
+# component distribution CDFs minus p, so it serves both to evaluate the
+# CDF (with p = 0) and as the objective for root finding (see root()).
+pmulti_fun <- function(dists) {
+  function(q, p = 0) {
+    terms <- purrr::imap(dists, function(pars, dist) {
+      weight <- pars$weight
+      pars$weight <- NULL
+      fun <- get(paste0("p", dist, "_ssd"), mode = "function")
+      weight * do.call(fun, c(list(q), pars))
+    })
+    purrr::reduce(terms, `+`) - p
+  }
 }
 
 normalize_weights <- function(list) {

--- a/R/pqr.R
+++ b/R/pqr.R
@@ -238,8 +238,7 @@ mdist <- function(dist) {
 
 tdist <- function(dist, data, pars, pvalue, test = "ks", y = "y") {
   x <- mean_weighted_values(data, weight = FALSE)
-  fun <- paste0("ssd_p", dist)
-  fun <- eval(parse(text = fun))
+  fun <- match.fun(paste0("ssd_p", dist))
   args <- list(x, fun)
   names(args) <- c("x", y)
   args <- c(args, pars)


### PR DESCRIPTION
Addresses review finding on the `eval(parse(text = ...))` metaprogramming in `multi.R` and `pqr.R`. Building executable R as a string defeats static analysis, hides errors until runtime, and is fragile to number/name formatting.

> **Stacked on #161** (base branch `joethorley/refactor-multi`), since it also touches `multi.R`. GitHub will retarget this to `dev` automatically once #161 merges. Review/merge #161 first.

## Changes

- **`pmulti_fun()`** previously pasted together a string like `"function(q, p = 0) {(0.5 * plnorm_ssd(q, meanlog = 0, sdlog = 1) + ...) - p}"` and `eval(parse())`-ed it. It now returns a closure that directly sums `weight * pXXX_ssd(q, ...)` over the component distributions. The component CDF is resolved with `get(..., mode = "function")` for lexical lookup (so it works when called from within `purrr::imap`). The now-unused string helpers `value_args()` and `pmulti_dist()` are removed.
- **`tdist()`** resolved `ssd_p<dist>` via `eval(parse(text = ...))`; now uses `match.fun()`.

## Verification

The TMB DLL will not load in the dev sandbox, so the suite was not run here. Output was verified **identical to the string-based implementation** by injecting the old (string) and new (closure) `pmulti_fun` into the installed namespace and comparing across a battery: p/q/r, distribution mixtures, `lower.tail`/`log.p`, p/q round-trips, and seeded random generation - all identical. Separately confirmed `match.fun(paste0("ssd_p", dist))` resolves the same function object as `eval(parse())` for every distribution (including `multi`).

Please still run `devtools::test()` (especially `test-multi` and the gof tests exercising `tdist`) and `devtools::check()` locally before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)