### PR TITLE
Deduplicate proportion handling, tighten validation and messages

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,3 +25,4 @@
 .devcontainer
 ^\.vscode$
 ^[.]?air[.]toml$
+^\.claude$

--- a/R/ggproto.R
+++ b/R/ggproto.R
@@ -114,7 +114,7 @@ GeomXribbon <- ggproto(
     # Check that aesthetics are constant
     aes <- unique(data[c("colour", "fill", "linewidth", "linetype", "alpha")])
     if (nrow(aes) > 1) {
-      err("Aesthetics can not vary with a ribbon.")
+      err("Aesthetics cannot vary with a ribbon.")
     }
     aes <- as.list(aes)
 

--- a/R/hc.R
+++ b/R/hc.R
@@ -65,6 +65,27 @@ ssd_hc <- function(x, ...) {
   )
 }
 
+# Resolve the deprecated `percent` argument into a `proportion` and
+# validate it. Shared by the ssd_hc() and predict() methods.
+.hc_proportion <- function(percent, proportion) {
+  if (lifecycle::is_present(percent)) {
+    lifecycle::deprecate_soft(
+      "2.0.0",
+      "ssd_hc(percent)",
+      "ssd_hc(proportion)",
+      id = "hc"
+    )
+    chk_vector(percent)
+    chk_numeric(percent)
+    chk_range(percent, c(0, 100))
+    proportion <- percent / 100
+  }
+  chk_vector(proportion)
+  chk_numeric(proportion)
+  chk_range(proportion)
+  proportion
+}
+
 #' @describeIn ssd_hc Hazard Concentrations for Distributional Estimates
 #' @export
 #' @examples
@@ -81,22 +102,7 @@ ssd_hc.list <- function(
   chk_unique(names(x))
   chk_unused(...)
 
-  if (lifecycle::is_present(percent)) {
-    lifecycle::deprecate_soft(
-      "2.0.0",
-      "ssd_hc(percent)",
-      with = "ssd_hc(proportion)",
-      id = "hc"
-    )
-    chk_vector(percent)
-    chk_numeric(percent)
-    chk_range(percent, c(0, 100))
-    proportion <- percent / 100
-  }
-
-  chk_vector(proportion)
-  chk_numeric(proportion)
-  chk_range(proportion)
+  proportion <- .hc_proportion(percent, proportion)
 
   if (!length(x)) {
     hc <- no_hcp()
@@ -140,22 +146,7 @@ ssd_hc.fitdists <- function(
 ) {
   chk_unused(...)
 
-  if (lifecycle::is_present(percent)) {
-    lifecycle::deprecate_soft(
-      "2.0.0",
-      "ssd_hc(percent)",
-      "ssd_hc(proportion)",
-      id = "hc"
-    )
-    chk_vector(percent)
-    chk_numeric(percent)
-    chk_range(percent, c(0, 100))
-    proportion <- percent / 100
-  }
-
-  chk_vector(proportion)
-  chk_numeric(proportion)
-  chk_range(proportion)
+  proportion <- .hc_proportion(percent, proportion)
 
   if (lifecycle::is_present(multi_est)) {
     lifecycle::deprecate_soft(
@@ -229,22 +220,7 @@ ssd_hc.fitburrlioz <- function(
   chk_subset(names(x), c("burrIII3", "invpareto", "llogis", "lgumbel"))
   chk_unused(...)
 
-  if (lifecycle::is_present(percent)) {
-    lifecycle::deprecate_soft(
-      "2.0.0",
-      "ssd_hc(percent)",
-      "ssd_hc(proportion)",
-      id = "hc"
-    )
-    chk_vector(percent)
-    chk_numeric(percent)
-    chk_range(percent, c(0, 100))
-    proportion <- percent / 100
-  }
-
-  chk_vector(proportion)
-  chk_numeric(proportion)
-  chk_range(proportion)
+  proportion <- .hc_proportion(percent, proportion)
 
   fun <- if (names(x) == "burrIII3") fit_burrlioz else fit_tmb
 

--- a/R/hp.R
+++ b/R/hp.R
@@ -68,8 +68,8 @@ ssd_hp.fitdists <- function(
   if (lifecycle::is_present(multi_est)) {
     lifecycle::deprecate_soft(
       "2.3.1",
-      "ssd_hc(multi_est)",
-      "ssd_hc(est_method)"
+      "ssd_hp(multi_est)",
+      "ssd_hp(est_method)"
     )
 
     chk_flag(multi_est)
@@ -156,7 +156,7 @@ ssd_hp.fitburrlioz <- function(
       "2.3.1",
       I("ssd_hp(proportion = FALSE)"),
       I("ssd_hp(proportion = TRUE)"),
-      "Please set the `proportion` argument to `ssd_hp_bcanz()` to be TRUE which will cause it to return hazard proportions instead of percentages then update your downstream code accordingly.",
+      "Please set the `proportion` argument to `ssd_hp()` to be TRUE which will cause it to return hazard proportions instead of percentages then update your downstream code accordingly.",
       id = "ssd_hp"
     )
   }

--- a/R/plot-data.R
+++ b/R/plot-data.R
@@ -58,6 +58,7 @@ ssd_plot_data <- function(
   chk_range(add_x, c(-1000, 1000))
   chk_string(big.mark)
   chk_string(decimal.mark)
+  chk_string(suffix)
 
   .chk_bounds(bounds)
 

--- a/R/pqr.R
+++ b/R/pqr.R
@@ -42,7 +42,7 @@ NULL
   args <- c(q, list(...))
 
   if (any(vapply(args, length, 1L) != 1L)) {
-    stop()
+    err("`q` and the distribution parameters must each be length 1.")
   }
   if (is.nan(q)) {
     return(NaN)
@@ -104,7 +104,7 @@ pdist <- function(
   args <- c(p, list(...))
 
   if (any(vapply(args, length, 1L) != 1L)) {
-    stop()
+    err("`p` and the distribution parameters must each be length 1.")
   }
   if (is.nan(p)) {
     return(NaN)

--- a/R/predict.R
+++ b/R/predict.R
@@ -49,22 +49,7 @@ predict.fitdists <- function(
 ) {
   chk_unused(...)
 
-  if (lifecycle::is_present(percent)) {
-    lifecycle::deprecate_soft(
-      "2.0.0",
-      "ssd_hc(percent)",
-      "ssd_hc(proportion)",
-      id = "hc"
-    )
-    chk_vector(percent)
-    chk_numeric(percent)
-    chk_range(percent, c(0, 100))
-    proportion <- percent / 100
-  }
-
-  chk_vector(proportion)
-  chk_numeric(proportion)
-  chk_range(proportion)
+  proportion <- .hc_proportion(percent, proportion)
 
   ssd_hc(
     object,
@@ -108,22 +93,7 @@ predict.fitburrlioz <- function(
 ) {
   chk_unused(...)
 
-  if (lifecycle::is_present(percent)) {
-    lifecycle::deprecate_soft(
-      "2.0.0",
-      "ssd_hc(percent)",
-      "ssd_hc(proportion)",
-      id = "hc"
-    )
-    chk_vector(percent)
-    chk_numeric(percent)
-    chk_range(percent, c(0, 100))
-    proportion <- percent / 100
-  }
-
-  chk_vector(proportion)
-  chk_numeric(proportion)
-  chk_range(proportion)
+  proportion <- .hc_proportion(percent, proportion)
 
   ssd_hc(
     object,

--- a/R/ssd-plot.R
+++ b/R/ssd-plot.R
@@ -155,10 +155,12 @@ ssd_plot <- function(
 
   if (!is.null(hc)) {
     chk_vector(hc)
+    chk_numeric(hc)
     chk_gt(length(hc))
     chk_subset(hc, pred$proportion)
   }
   chk_string(big.mark)
+  chk_string(decimal.mark)
   chk_string(suffix)
   .chk_bounds(bounds)
   chk_subset(trans, c("log10", "log", "identity"))


### PR DESCRIPTION
Lower-priority polish from the code review: removes duplicated validation, closes a few input-validation gaps, and fixes incorrect user-facing messages. No behaviour change for valid inputs.

## Changes

- **Deduplicate `percent` -> `proportion` handling.** The identical 12-line deprecation-and-validation block was copy-pasted across `ssd_hc.list`/`ssd_hc.fitdists`/`ssd_hc.fitburrlioz` and `predict.fitdists`/`predict.fitburrlioz`. Extracted into one `.hc_proportion()` helper. The helper is verbatim the previous logic, and forwarding a not-supplied `percent` (whether defaulted to `deprecated()` or bare-missing) works unchanged.
- **Validation gaps** (each sibling validated a complementary-but-incomplete set):
  - `ssd_plot()` now checks `hc` is numeric (before `chk_subset`, giving a clear error instead of a confusing subset failure) and that `decimal.mark` is a string.
  - `ssd_plot_data()` now checks `suffix` is a string.
- **`.pd()`/`.qd()`** replace the bare `stop()` length-1 assertion with `err()` carrying a message.
- **Message fixes:** two `ssd_hp()` deprecation messages referred to `ssd_hc()` and `ssd_hp_bcanz()`; corrected to `ssd_hp()`. Fixed "can not" -> "cannot" in the `GeomXribbon` error.

## Deliberately excluded

The reviewer also flagged adding `chk_gte(conc, 0)`/`chk_not_any_na(conc)` to `ssd_hp()`. On inspection this is **not** a real gap: a negative `conc` correctly yields `P(X <= conc) = 0` (e.g. `plnorm(-1) == 0`) and `NA` yields `NA`. Adding `chk_gte(conc, 0)` would reject a mathematically valid query, so it was left out.

## Verification

TMB DLL will not load in the dev sandbox, so the suite was not run here. The `.hc_proportion()` helper was verified to return identical output to the old inline blocks across the supplied / not-supplied / invalid `percent` and `proportion` paths, and to still reject out-of-range values. Other changes are added validation / message text only. Please run `devtools::test()` and `devtools::check()` locally before merge.

Independent of #160/#161/#162 (different functions); branches from `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)