### PR TITLE
Remove dead parameters and tidy minor cleanups

### DIFF
--- a/R/boot.R
+++ b/R/boot.R
@@ -30,12 +30,7 @@ sample_nonparametric <- function(data) {
   data[sample(nrow(data), replace = TRUE), ]
 }
 
-sample_parametric <- function(
-  dist,
-  args = args,
-  weighted = weighted,
-  censoring = censoring
-) {
+sample_parametric <- function(dist, args, weighted, censoring) {
   what <- paste0("ssd_r", dist)
   args$chk <- FALSE
   sample <- do.call(what, args)

--- a/R/burrrIII3.R
+++ b/R/burrrIII3.R
@@ -98,7 +98,7 @@ sburrIII3 <- function(data, pars = NULL) {
   list(log_scale = 0, log_shape1 = 0, log_shape2 = 0)
 }
 
-bburrIII3 <- function(x, range_shape1, range_shape2, ...) {
+bburrIII3 <- function(range_shape1, range_shape2, ...) {
   log_range_shape1 <- log(range_shape1)
   log_range_shape2 <- log(range_shape2)
   list(

--- a/R/hcp-average.R
+++ b/R/hcp-average.R
@@ -25,7 +25,7 @@ hcp_noci <- function(value, est_method, ci_method, ...) {
   tibble(
     value = value,
     est_method = est_method,
-    ci_method = ci_method,
+    ci_method = ci_method
   )
 }
 

--- a/R/hcp-samples.R
+++ b/R/hcp-samples.R
@@ -62,7 +62,7 @@ hcp_combine_samples <- function(hcp, weight, ci_method, level, nboot) {
       samples = list(combine_samples(
         .data$samples,
         weight,
-        nboot = nboot,
+        nboot = .env$nboot,
         geometric = geometric
       ))
     ) |>

--- a/R/hcp-samples.R
+++ b/R/hcp-samples.R
@@ -55,7 +55,6 @@ combine_samples <- function(samples, weight, nboot, geometric) {
 hcp_combine_samples <- function(hcp, weight, ci_method, level, nboot) {
   geometric <- ci_method == "geometric_samples"
 
-  nboot1 <- nboot
   hcp <- hcp |>
     dplyr::bind_rows() |>
     dplyr::group_by(.data$value) |>
@@ -63,7 +62,7 @@ hcp_combine_samples <- function(hcp, weight, ci_method, level, nboot) {
       samples = list(combine_samples(
         .data$samples,
         weight,
-        nboot = nboot1,
+        nboot = nboot,
         geometric = geometric
       ))
     ) |>

--- a/R/hcp.R
+++ b/R/hcp.R
@@ -29,7 +29,7 @@ hcp_unscale <- function(hcp, rescale) {
 }
 
 ## no_hcp is returned without tidying so must be complete
-no_hcp <- function(hc) {
+no_hcp <- function() {
   tibble(
     dist = character(0),
     value = numeric(0),
@@ -74,8 +74,8 @@ clean_hcp <- function(
     hcp$pboot <- 1
   }
 
-  if (any(hcp$pboot < min_pboot)) {
-    fail <- hcp$pboot < min_pboot
+  fail <- !is.na(hcp$pboot) & hcp$pboot < min_pboot
+  if (any(fail)) {
     hcp$lcl[fail] <- NA_real_
     hcp$ucl[fail] <- NA_real_
     hcp$se[fail] <- NA_real_

--- a/R/llogis-llogis.R
+++ b/R/llogis-llogis.R
@@ -137,7 +137,7 @@ sllogis_llogis <- function(data, pars = NULL) {
   c(s1, s2, pmix)
 }
 
-bllogis_llogis <- function(x, min_pmix, ...) {
+bllogis_llogis <- function(min_pmix, ...) {
   list(
     lower = list(
       locationlog1 = -Inf,

--- a/R/lnorm-lnorm.R
+++ b/R/lnorm-lnorm.R
@@ -135,7 +135,7 @@ slnorm_lnorm <- function(data, pars = NULL) {
   c(s1, s2, pmix)
 }
 
-blnorm_lnorm <- function(x, min_pmix, ...) {
+blnorm_lnorm <- function(min_pmix, ...) {
   list(
     lower = list(
       meanlog1 = -Inf,


### PR DESCRIPTION
Lower-priority polish from the code review. **No behaviour change** - these remove unused arguments and dead/fragile code.

## Changes

- **`no_hcp()`** drops the unused `hc` parameter (both call sites already pass none).
- **`bburrIII3()` / `blnorm_lnorm()` / `bllogis_llogis()`** drop the unused leading `x` parameter. `bdist()` dispatches to them with named arguments (`data`, `min_pmix`, `range_shape1`, `range_shape2`), so `x` was never filled and `data` fell through to `...`. Verified the named-argument dispatch still resolves correctly with `x` removed.
- **`sample_parametric()`** drops the self-referential `args = args` / `weighted = weighted` / `censoring = censoring` default bindings (a footgun that only "worked" because the sole caller always supplies them).
- **`clean_hcp()`** guards the `min_pboot` mask with `!is.na(pboot)`, matching the existing `replace_min_pboot_na()`. Identical result when `pboot` has no `NA`; NA-safe when it does (previously `any(NA < min_pboot)` could error the `if()`).
- **`hcp_combine_samples()`** drops the redundant `nboot1` alias - `nboot` is a function argument (not a column), so it resolves directly inside `summarise()` exactly like the sibling `weight`/`geometric` arguments in the same call.
- **`hcp_noci()`** removes a trailing comma in the `tibble()` call.

## Verification

TMB DLL will not load in the dev sandbox, so the suite was not run here. Verified statically: the `b*` named-argument dispatch resolves with `x` removed; the `clean_hcp` mask is identical to the old logic when `pboot` has no `NA` and is NA-safe otherwise; both `no_hcp()` call sites pass no argument; `sample_parametric`'s only caller passes all arguments. Please run `devtools::test()` and `devtools::check()` locally before merge.

Independent of #160/#161/#162/#163 (different functions); branches from `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)