### PR TITLE
Add CODEOWNERS naming @joethorley

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joethorley


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @joethorley`.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)