### PR TITLE
AICc is now `Inf` when the number of observations is less than the number of parameters plus two as the small sample correction is undefined

### DIFF
--- a/R/glance.R
+++ b/R/glance.R
@@ -23,7 +23,11 @@ generics::glance
   npars <- npars(x)
   log_lik <- logLik(x)
   aic <- 2 * npars - 2 * log_lik
-  aicc <- aic + 2 * npars * (npars + 1) / (nobs - npars - 1)
+  if (isTRUE(nobs < npars + 2)) {
+    aicc <- Inf
+  } else {
+    aicc <- aic + 2 * npars * (npars + 1) / (nobs - npars - 1)
+  }
 
   tibble(
     dist = dist,
@@ -38,6 +42,10 @@ generics::glance
 #' Get a tibble summarizing each distribution
 #'
 #' Gets a tibble with a single row for each distribution.
+#'
+#' The `aicc` is `Inf` if the number of observations is less than
+#' the number of parameters plus two as the small sample size
+#' correction is undefined.
 #'
 #' @inheritParams params
 #' @return A tidy tibble of the distributions.

--- a/man/glance.fitdists.Rd
+++ b/man/glance.fitdists.Rd
@@ -19,6 +19,11 @@ A tidy tibble of the distributions.
 \description{
 Gets a tibble with a single row for each distribution.
 }
+\details{
+The \code{aicc} is \code{Inf} if the number of observations is less than
+the number of parameters plus two as the small sample size
+correction is undefined.
+}
 \examples{
 fits <- ssd_fit_dists(ssddata::ccme_boron)
 glance(fits, wt = TRUE)

--- a/tests/testthat/test-glance.R
+++ b/tests/testthat/test-glance.R
@@ -76,6 +76,26 @@ test_that("glance reweight same log_lik", {
   expect_equal(glance_weight$log_lik, glance$log_lik)
 })
 
+test_that("glance aicc is Inf when nobs < npars + 2", {
+  data <- data.frame(Conc = c(0.1, 0.3, 1, 3, 10))
+  fit <- ssd_fit_dists(data, dists = c("lnorm", "lnorm_lnorm"), nrow = 5)
+
+  glance <- glance(fit, wt = TRUE)
+  expect_identical(glance$nobs, c(5L, 5L))
+  expect_true(is.finite(glance$aicc[glance$dist == "lnorm"]))
+  expect_identical(glance$aicc[glance$dist == "lnorm_lnorm"], Inf)
+  expect_identical(glance$wt[glance$dist == "lnorm_lnorm"], 0)
+})
+
+test_that("glance aicc finite when nobs >= npars + 2", {
+  data <- data.frame(Conc = c(0.1, 0.3, 1, 3, 10, 30, 100))
+  fit <- ssd_fit_dists(data, dists = c("lnorm", "lnorm_lnorm"))
+
+  glance <- glance(fit, wt = TRUE)
+  expect_identical(glance$nobs, c(7L, 7L))
+  expect_true(all(is.finite(glance$aicc)))
+})
+
 test_that("glance reweight same log_lik", {
   data <- ssddata::ccme_boron
   data$Upper <- data$Conc


### PR DESCRIPTION
Closes #175

For a distribution with `k` parameters and `n` observations the AICc correction term `2*k*(k+1) / (n - k - 1)` has a non-positive denominator when `n <= k + 1`, so at `n = k` the criterion rewarded the over-parameterised distribution (e.g. the 5-parameter `lnorm_lnorm` mixture received essentially all the AICc weight at `n = 5`).

`glance()` (and hence `ssd_gof()` and all AICc-based model averaging) now returns `AICc = Inf` when `nobs < npars + 2` so such a distribution receives zero weight rather than a degenerate reward. Censored data behaviour (`aicc = NA`) is unchanged.

- Guard added in `.glance_tmbfit()` with `isTRUE()` to preserve `NA` propagation for censored data.
- Tests added for `n = npars` (now `Inf`) and `n >= npars + 2` (finite).
- Documented in `glance.fitdists()`.

Full test suite passes locally (1336 tests, 0 failures, NOT_CRAN=true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)