### PR TITLE
Standardize CI on dev (tier: cran)

### DIFF
--- a/.github/workflows/check-no-suggests.yaml
+++ b/.github/workflows/check-no-suggests.yaml
@@ -1,4 +1,4 @@
-name: R-CMD-check
+name: check-no-suggests
 on:
   push:
     branches: [main, master]
@@ -7,12 +7,8 @@ on:
 permissions:
   contents: read
 jobs:
-  R-CMD-check:
-    uses: poissonconsulting/.github/.github/workflows/R-CMD-check.yaml@v1
+  check-no-suggests:
+    uses: poissonconsulting/.github/.github/workflows/check-no-suggests.yaml@v1
     with:
-      tier: cran
-      jags: false
-      cmdstan: false
-      tex: true
       private: false
     secrets: inherit

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,49 +1,18 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+name: pkgdown
 on:
   push:
     branches: [main, master]
   pull_request:
+    branches: [main, master, dev]
   release:
     types: [published]
   workflow_dispatch:
-
-name: pkgdown.yaml
-
-permissions: read-all
-
+permissions:
+  contents: write
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::pkgdown, local::.
-          needs: website
-
-      - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
-        shell: Rscript {0}
-
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
-        with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+    uses: poissonconsulting/.github/.github/workflows/pkgdown.yaml@v1
+    with:
+      cmdstan: false
+      private: false
+    secrets: inherit

--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -5,6 +5,10 @@
 # rhub::rhub_setup()
 #
 # It is unlikely that you need to modify this file manually.
+#
+# Distributed to CRAN-tier packages by poissonconsulting/.github tools/sync-ci.sh.
+# It is dispatch-triggered (run via rhub::rhub_check()), not a push/PR check, so it
+# is vendored as-is rather than called as a reusable workflow.
 
 name: R-hub
 run-name: "${{ github.event.inputs.id }}: ${{ github.event.inputs.name || format('Manually run by {0}', github.triggering_actor) }}"

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,62 +1,16 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+name: test-coverage
 on:
   push:
-    branches: main
+    branches: [main, master]
   pull_request:
-
-name: test-coverage.yaml
-
-permissions: read-all
-
+    branches: [main, master, dev]
+permissions:
+  contents: read
 jobs:
   test-coverage:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::covr, any::xml2
-          needs: coverage
-
-      - name: Test coverage
-        run: |
-          cov <- covr::package_coverage(
-            quiet = FALSE,
-            clean = FALSE,
-            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
-          )
-          print(cov)
-          covr::to_cobertura(cov)
-        shell: Rscript {0}
-
-      - uses: codecov/codecov-action@v7
-        with:
-          # Fail if error if not on PR, or if on PR and token is given
-          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
-          files: ./cobertura.xml
-          plugins: noop
-          disable_search: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Show testthat output
-        if: always()
-        run: |
-          ## --------------------------------------------------------------------
-          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload test results
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-test-failures
-          path: ${{ runner.temp }}/package
+    uses: poissonconsulting/.github/.github/workflows/test-coverage.yaml@v1
+    with:
+      cmdstan: false
+      tex: true
+      private: false
+    secrets: inherit


### PR DESCRIPTION
Replaces the standalone r-lib workflows on `dev` with thin callers to the reusable CI in `poissonconsulting/.github` (tier **cran**, private=false, jags=false, cmdstan=false, tex=true). Callers: R-CMD-check, test-coverage, pkgdown, check-no-suggests; `slack-check-package.yaml` preserved; `rhub.yaml` refreshed from the template.

The callers trigger on pull requests targeting `main`, `master`, or `dev`, so PRs to this fork's `dev` integration branch now run all checks (the upstream workflows only trigger on `main`). pkgdown builds without deploying on pull requests.

Targets `dev` (not `main`) so `main` stays a clean mirror of `bcgov/ssdtools`; feature branches cut from `main` remain free of these caller files for upstream PRs. Note: `dev` is a rebuildable integration branch, so this commit needs re-applying if `dev` is ever rebuilt from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)