### PR TITLE
`ssd_hc()` and `ssd_hp()` return one row per input value when values are duplicated

### DIFF
--- a/R/hcp-average.R
+++ b/R/hcp-average.R
@@ -58,6 +58,11 @@ hcp_average <- function(
     )
   }
 
+  ## Compute on the unique values so the various ci/est functions (some of
+  ## which collapse duplicates via group_by()) agree on the row structure,
+  ## then re-expand to the input `value` vector preserving order and duplicates.
+  uvalue <- unique(value)
+
   est_same <- FALSE
   ci_fun <- if (!ci) {
     hcp_noci
@@ -75,7 +80,7 @@ hcp_average <- function(
 
   hcp <- ci_fun(
     x,
-    value = value,
+    value = uvalue,
     ci = ci,
     level = level,
     nboot = nboot,
@@ -98,7 +103,7 @@ hcp_average <- function(
   )
 
   if (est_same) {
-    return(hcp)
+    return(hcp[match(value, hcp$value), ])
   }
 
   est_fun <- if (est_method == "multi") {
@@ -108,7 +113,7 @@ hcp_average <- function(
   }
   est <- est_fun(
     x,
-    value,
+    uvalue,
     ci = FALSE,
     level = level,
     nboot = nboot,
@@ -128,5 +133,6 @@ hcp_average <- function(
     ci_method = "MACL",
     hc = hc
   )
-  replace_estimates(hcp, est)
+  hcp <- replace_estimates(hcp, est)
+  hcp[match(value, hcp$value), ]
 }

--- a/tests/testthat/test-hc.R
+++ b/tests/testthat/test-hc.R
@@ -1229,3 +1229,14 @@ test_that("ssd_hc fitdists arithmetic_samples ci", {
   expect_s3_class(hc, "tbl_df")
   expect_snapshot_data(hc, "hc_arithmetic_samples")
 })
+
+test_that("hc duplicate proportion values return one row per input value in order", {
+  fits <- ssd_fit_dists(ssddata::ccme_boron)
+
+  hc <- ssd_hc(fits, proportion = c(0.05, 0.1, 0.2))
+  hc_dup <- ssd_hc(fits, proportion = c(0.05, 0.1, 0.2, 0.05))
+
+  expect_identical(nrow(hc_dup), 4L)
+  expect_identical(hc_dup$proportion, c(0.05, 0.1, 0.2, 0.05))
+  expect_equal(hc_dup$est, c(hc$est, hc$est[1]))
+})

--- a/tests/testthat/test-hp.R
+++ b/tests/testthat/test-hp.R
@@ -659,6 +659,25 @@ test_that("hp est_method = FALSE deprecated and overrides est_method", {
   expect_identical(false, arithmetic)
 })
 
+test_that("hp duplicate conc values return one row per input value in order", {
+  fits <- ssd_fit_dists(ssddata::ccme_boron)
+
+  hp <- ssd_hp(fits, conc = c(1, 10, 20), proportion = TRUE)
+  hp_dup <- ssd_hp(fits, conc = c(1, 10, 20, 1), proportion = TRUE)
+
+  expect_identical(nrow(hp_dup), 4L)
+  expect_identical(hp_dup$conc, c(1, 10, 20, 1))
+  expect_equal(hp_dup$est, c(hp$est, hp$est[1]))
+})
+
+test_that("hp duplicate conc values unaffected when average = FALSE", {
+  fits <- ssd_fit_dists(ssddata::ccme_boron)
+
+  hp <- ssd_hp(fits, conc = c(1, 10, 1), average = FALSE, proportion = TRUE)
+  expect_identical(nrow(hp), 18L)
+  expect_identical(unique(hp$conc), c(1, 10))
+})
+
 test_that("hp ci_method = 'weighted_arithmetic' deprecated for MACL", {
   fits <- ssd_fit_dists(ssddata::ccme_boron)
   withr::with_seed(10, {


### PR DESCRIPTION
Closes #141

## Problem

With duplicate values in the model-averaged path, `ssd_hp()` (and `ssd_hc()`) returned more rows than the input vector:

```r
boron <- ssd_fit_dists(ssddata::ccme_boron)
ssd_hp(boron, proportion = TRUE, conc = c(1, 10, 20, 1))
#> 6 rows instead of 4
```

The averaged path passed the raw `value` vector (with duplicates) to `replace_estimates()`, whose `inner_join(..., by = "value")` became many-to-many, multiplying the duplicated rows. The non-averaged path (`average = FALSE`) was already correct.

## Fix

`hcp_average()` now computes on the unique values (so the various ci/est helpers, some of which collapse duplicates via `group_by()`, agree on row structure) and re-expands to the input `value` vector via `match()`, preserving input order and duplicates. The averaged path always yields one row per value, so the re-expansion is unambiguous.

Verified correct across `ci = FALSE`, `ci = TRUE`, and `est_method = "arithmetic"`. The non-averaged path is unchanged.

## Tests

- `ssd_hp()` / `ssd_hc()` with duplicate values return one row per input value in input order.
- Regression test that `average = FALSE` is unaffected.

Full test suite passes locally (1344 tests, 0 failures, NOT_CRAN=true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)