### PR TITLE
Guard latex2exp vignette chunk for no-suggests builds

### DIFF
--- a/vignettes/faqs.Rmd
+++ b/vignettes/faqs.Rmd
@@ -32,7 +32,7 @@ ssd_plot_cdf(dist, average = NA)
 
 ### How can I include mathematical expressions in the x-axis label when using `ssd_plot()`?
 
-```{r, message = FALSE, fig.alt = "A plot showing the model averaged fit with a mathematical expression in the xlabel with the units."}
+```{r, message = FALSE, eval = requireNamespace("latex2exp", quietly = TRUE), fig.alt = "A plot showing the model averaged fit with a mathematical expression in the xlabel with the units."}
 library(ssdtools)
 
 ssd_plot(ssddata::ccme_boron, ssdtools::boron_pred, label = "Species", shape = "Group") +


### PR DESCRIPTION
`latex2exp` is in `Suggests` but the `faqs.Rmd` chunk at line 35 called `latex2exp::TeX()` unconditionally, so vignette re-building fails when the package is not installed — as in the `check-no-suggests` workflow (hard dependencies only), the red check on #177. CRAN policy requires suggested packages to be used conditionally.

Adds `eval = requireNamespace("latex2exp", quietly = TRUE)` to the chunk options so the chunk (and its figure) is skipped when `latex2exp` is absent; normal builds with Suggests installed are unchanged. The similar call in `vignettes/articles/customising-plots.Rmd` is untouched since articles are not built during `R CMD check`.

Branched from `main` so the fix can be PRed upstream to `bcgov/ssdtools` independently of the CI-caller commit on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)